### PR TITLE
Fix handling of ATR images with more than 256 bytes per sector

### DIFF
--- a/diskimageatr.cpp
+++ b/diskimageatr.cpp
@@ -812,7 +812,7 @@ bool SimpleDiskImage::seekToSector(quint16 sector)
     qint64 pos = (sector - 1) * m_geometry.bytesPerSector();
     // all sectors in a XFD file have the same size (this is the difference with the ATR format).
     // For example, XFD files are used to store CP/M disk images with 256 bytes boot sectors for Indus GT with RamCharger (not possible with ATR files).
-    if ((m_geometry.bytesPerSector() != 128) && (m_originalImageType != FileTypes::Xfd) && (m_originalImageType != FileTypes::XfdGz)) {
+    if ((m_geometry.bytesPerSector() == 256) && (m_originalImageType != FileTypes::Xfd) && (m_originalImageType != FileTypes::XfdGz)) {
         if (sector <= 3) {
             pos = (sector - 1) * 128;
         } else {


### PR DESCRIPTION
Commit 63dfb8da "Add ATX support and SIO emulation of Chip 810, Super
Archiver 1050, Happy 810 Rev.5 and Happy 1050 Rev.7" incorrectly
changed the sector size check in seekToSector() which lead to
wrong data being accessed when using ATR images with more than
256 bytes per sector.

This soft-bricked The!Carts which uses ATR programming images
with 8k sector size.

Fix this by reverting back to the previous check logic, only ATRs
with 256 bytes per sector have the first three sectors stored with
128 bytes, all other variants use ATRs with uniform sector sizes.