### PR TITLE
add scaling for high dpi displays

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -22,7 +22,7 @@ int main(int argc, char *argv[])
 #ifdef Q_OS_WIN
     timeBeginPeriod(1);
 #endif
-
+    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QApplication a(argc, argv);
     QTextCodec::setCodecForLocale(QTextCodec::codecForName("UTF-8"));
     MainWindow w;


### PR DESCRIPTION
I noticed on Windows that on my 4k monitor the options screen was not displaying properly. This line of code fixed it for me.

_I hope I did this right (and it is acceptable to submit a pull request on this project) - I haven't tried to contribute to another project before and this is in fact a *really* trivial change._