### PR TITLE
add stdexcept library to atascii.cpp

### DIFF
--- a/atascii.cpp
+++ b/atascii.cpp
@@ -1,4 +1,5 @@
 #include "atascii.h"
+#include <stdexcept>
 
 std::map<unsigned char, QChar> Atascii::mapping;
 Atascii::Atascii()


### PR DESCRIPTION
fix compile error on Linux for atari.cpp related to issue #5 